### PR TITLE
Add Jenkinsfile to list of file types with Groovy syntax

### DIFF
--- a/src/Bundles/groovy/Syntaxes/Groovy.tmLanguage
+++ b/src/Bundles/groovy/Syntaxes/Groovy.tmLanguage
@@ -6,6 +6,7 @@
 	<array>
 		<string>groovy</string>
 		<string>gvy</string>
+		<string>Jenkinsfile</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(\{\s*$|^\s*// \{\{\{)</string>

--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -13,6 +13,6 @@ namespace TextmateBundleInstaller
         public const string Language = "en-US";
         public const string Version = "2.8";
         public const string Author = "Mads Kristensen";
-        public const string Tags = "bat, clojure, go, goovy, ini, jade, java, javadoc, lua, make, perl, php, ruby, rust, bash, swift";
+        public const string Tags = "bat, clojure, go, groovy, ini, jade, java, javadoc, lua, make, perl, php, ruby, rust, bash, swift";
     }
 }


### PR DESCRIPTION
- Also fix misspelling of "groovy" tag in Vsix definition

I have an open PR with textmate/groovy.tmbundle to replicate this change at the source: https://github.com/textmate/groovy.tmbundle/pull/18