### PR TITLE
support for mk makefiles. bump version to 2.8.2

### DIFF
--- a/src/Bundles/make/Syntaxes/Makefile.plist
+++ b/src/Bundles/make/Syntaxes/Makefile.plist
@@ -4,6 +4,9 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
+		<string>mk</string>
+		<string>MK</string>
+		<string>Mak</string>
 		<string>mak</string>
 		<string>Makefile</string>
 		<string>makefile</string>

--- a/src/Commands/CommentRegistration.cs
+++ b/src/Commands/CommentRegistration.cs
@@ -57,6 +57,7 @@ namespace TextmateBundleInstaller
                 case ".javascript":
                 case ".json":
                 case ".less":
+                case ".mk":
                 case ".makefile":
                 case ".objective c":
                 case ".rust":

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="4773ce75-6f30-4269-9557-1f7c30a47be2" Version="2.8" Language="en-US" Publisher="Mads Kristensen" />
+        <Identity Id="4773ce75-6f30-4269-9557-1f7c30a47be2" Version="2.8.2" Language="en-US" Publisher="Mads Kristensen" />
         <DisplayName>Syntax Highlighting Pack</DisplayName>
         <Description xml:space="preserve">Adds syntax highlighting and snippet support for a wide variety of programming languages such as Clojure, Go, Jade, Lua, Swift, Ruby and many more...</Description>
         <MoreInfo>https://github.com/madskristensen/TextmateBundleInstaller</MoreInfo>


### PR DESCRIPTION
Syntax highlighting for makefiles with ".mk" files. Addresses: #520 #514 #499 #497 #431 and #313

